### PR TITLE
Docs and misc

### DIFF
--- a/nprime/__init__.py
+++ b/nprime/__init__.py
@@ -2,21 +2,17 @@
 nprime main application package
 
 Auto generate command:
-    mkinit nprime/__init__.py -w
+    mkinit nprime/__init__.py --nomods -w
 """
-
-from nprime import pyprime
-
-from nprime.pyprime import (fermat, find_primes, generate_primes, is_prime,
-                            miller_rabin, pyprime, sacks, sieve_eratosthenes,
-                            trial_division, ulam, )
-
-__all__ = ['fermat', 'find_primes', 'generate_primes', 'is_prime',
-           'miller_rabin', 'pyprime', 'pyprime', 'sacks',
-           'sieve_eratosthenes', 'trial_division', 'ulam', ]
-
 __submodules__ = [
     'pyprime',
 ]
 
 __version__ = '1.1.1'
+from nprime.pyprime import (fermat, find_primes, generate_primes, is_prime,
+                            miller_rabin, pyprime, sacks, sieve_eratosthenes,
+                            trial_division, ulam,)
+
+__all__ = ['fermat', 'find_primes', 'generate_primes', 'is_prime',
+           'miller_rabin', 'pyprime', 'sacks', 'sieve_eratosthenes',
+           'trial_division', 'ulam']

--- a/nprime/plot.py
+++ b/nprime/plot.py
@@ -1,5 +1,3 @@
-import matplotlib.pyplot as plt
-
 from nprime.pyprime import sacks, pyprime, ulam
 
 
@@ -11,6 +9,7 @@ def sacks_plot(upper=10000, prime_test_function=pyprime):  # pragma: no cover
     Return a polar plot of the sacks' diagram
 
     """
+    import matplotlib.pyplot as plt
     coord, prime_coord = sacks(upper, prime_test_function)
 
     plt.figure()
@@ -29,6 +28,7 @@ def ulam_plot(upper=10000, edge=4, prime_test_function=pyprime):  # pragma: no c
     Return a polar plot of the ulam's spiral
 
     """
+    import matplotlib.pyplot as plt
     coord, prime_coord = ulam(upper, edge, prime_test_function)
 
     plt.figure()

--- a/nprime/pyprime.py
+++ b/nprime/pyprime.py
@@ -17,6 +17,13 @@ def is_prime(n):
 
     Returns a boolean, True if n is prime.
 
+    Example:
+        >>> is_prime(101)
+        True
+        >>> is_prime(102)
+        False
+        >>> is_prime(103)
+        True
     """
     for i in range(2, int(pow(n, 0.5)) + 1):
         if n % i == 0:
@@ -32,6 +39,14 @@ def fermat(n, t=100):
     Prime probability is right is 1 - 1/(2^t)
     Returns a boolean: True if n passes the tests.
 
+    Example:
+        >>> # xdoctest: +IGNORE_WANT
+        >>> fermat(101)
+        True
+        >>> fermat(102)
+        False
+        >>> fermat(103)
+        True
     """
     for _ in range(0, t):
         a = random.randrange(1, n)
@@ -54,6 +69,14 @@ def miller_rabin(n, t=100):
 
     Returns a boolean: True if n passes the tests
 
+    Example:
+        >>> # xdoctest: +IGNORE_WANT
+        >>> miller_rabin(101)
+        True
+        >>> miller_rabin(102)
+        False
+        >>> miller_rabin(103)
+        True
     """
     if n == 2:
         prime = True  # To normalize and make the algorythm works with 2
@@ -88,22 +111,28 @@ def generate_primes(upper=0):
 
     Returns a list of integer.
 
+    Example:
+        >>> upper = 50
+        >>> primes = list(generate_primes(upper))
+        >>> print(primes)
+        [2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47]
     """
 
     if upper >= 2:
         primes = [2]
 
         for n in range(3, upper + 1):
-            k = 0
-
             # We only check if n is divided by the previous primes
-            while primes[k] <= pow(n, 0.5) and n % primes[k] != 0:
-                k += 1
-
-            # if a number has no dividers, last prime[k] of loop is over n's square root
-            if pow(n, 0.5) < primes[k]:
-                primes.append(n)
-
+            sqrt_n = pow(n, 0.5)
+            divisor = None
+            for p in primes:
+                if sqrt_n < p:
+                    break
+                if n % p == 0:
+                    divisor = p
+                    break  # not prime
+            if divisor is None:
+                primes.append(n)  # must be prime
     else:
         primes = []
 
@@ -117,6 +146,10 @@ def sieve_eratosthenes(upper):
     :return: a dictionary,
                 the key are the primes up to n
                 the value is the list of composites of these primes up to n
+
+    Example:
+        >>> upper = 100
+        >>> sieve_eratosthenes(upper)
     """
     primes = {}
     composites = set()
@@ -135,6 +168,10 @@ def trial_division(upper):
     :return: a dictionary,
                 the key are the primes up to n
                 the value is the list of composites of these primes up to n
+
+    Example:
+        >>> upper = 100
+        >>> trial_division(upper)
     """
 
     if isinstance(upper, int) and upper >= 2:
@@ -167,6 +204,10 @@ def find_primes(lower, upper, prime_test_function=is_prime):
 
     Returns a list of prime integer.
 
+    Example:
+        >>> upper = 100
+        >>> lower = 2
+        >>> find_primes(lower, upper)
     """
     if upper <= lower or lower <= 1:
         raise ValueError("We should have 1 < lower < upper")
@@ -212,6 +253,10 @@ def sacks(upper=1000, prime_test_function=pyprime):  # pragma: no cover
         1- The none prime polar coordinates: coord
         2- The prime polar coordinates: prime_coord
 
+    Example:
+        >>> coord, prime_coord = sacks(100)
+        >>> assert len(prime_coord) == 25
+        >>> assert len(coord) == 75
     """
     coord = []  # Normal numbers' polar value
     prime_coord = []  # Prime numbers' polar value
@@ -241,6 +286,10 @@ def ulam(upper=1000, edge=4, prime_test_function=pyprime):  # pragma: no cover
         1- The none prime polar coordinates: coord
         2- The prime polar coordinates: prime_coord
 
+    Example:
+        >>> coord, prime_coord = sacks(100)
+        >>> assert len(prime_coord) == 25
+        >>> assert len(coord) == 75
     """
     theta = 0  # Keep track of the spiral rotation
     psi = math.radians(360 / edge)  # Angle of the polygone's corner


### PR DESCRIPTION
With respect to #21, this moves the plt imports inside the functions, so the plot code can be imported at startup time. In the issue you mentioned the submodule logic takes care of this, and you're right, so I can drop 183a2a9 if necessary. 

Also in the `__init__.py` file I noticed there were two definitions of pyprime, one was the submodule and the other was the function. I removed that ambiguity by adding the `--nomods` flag to `mkinit`, which only exposes attributes and not the parent modules. However, there is still an ambiguity by exposing the `pyprime` attribute at the top level. There is now effectively no way to reference the `pyprime` module, which I believe breaks some of the examples. This can either be fixed by (1) reverting the mkinit change, (2) changing the name of the submodule to something like "core", (3) removing the pyprime function from the `__init__.py` file or (4) being ok with the loss of that module reference and declaring that core functions should always be used via the top level. Personally I prefer option 2. 

Almost lastly, I added several doctests to demonstrate usage of the module. These can be run automatically on TravisCI via installing [xdoctest](https://github.com/Erotemic/xdoctest) from pypi and including the lines `coverage run --source=nprime.pyprime -m xdoctest nprime` or if you switched to pytest you could test everything with one command:

```bash
pip install pytest pytest-cov xdoctest
pytest --xdoctest --cov=nprime --cov-report xml nprime tests
```

But either way, the examples should be helpful. 

Actually lastly, I slightly improved the efficiency of `generate_primes` by rougly (1.5x). I stored the sqrt computation in a variable to prevent recalculation and used pythonic iterables rather than index based loops. 

```python
def generate_primes_new(upper=0):
    if upper >= 2:
        primes = [2]
        for n in range(3, upper + 1):
            # We only check if n is divided by the previous primes
            sqrt_n = pow(n, 0.5)
            found = None
            # Test if any previous primes divides n
            for p in primes:
                if sqrt_n < p:
                    break
                if n % p == 0:
                    found = p
                    break  # not prime
            if found is None:
                primes.append(n)  # must be prime
    else:
        primes = []
    return primes


def generate_primes_old(upper=0):
    if upper >= 2:
        primes = [2]

        for n in range(3, upper + 1):
            # We only check if n is divided by the previous primes
            k = 0
            sqrt_n = pow(n, 0.5)

            while primes[k] <= sqrt_n and n % primes[k] != 0:
                k += 1

            # if a number has no dividers, last prime[k] of loop is over n's square root
            if sqrt_n < primes[k]:
                primes.append(n)
    else:
        primes = []

    return primes

import timerit
ti = timerit.Timerit(20, bestof=3, verbose=2)

upper = 50000
for timer in ti.reset('old'):
    with timer:
        list(generate_primes_old(upper))

for timer in ti.reset('new'):
    with timer:
        list(generate_primes_new(upper))
```

```
Timed old for: 20 loops, best of 3
    time per loop: best=66.917 ms, mean=67.662 ± 1.0 ms
Timed new for: 20 loops, best of 3
    time per loop: best=42.258 ms, mean=43.816 ± 1.0 ms
```