### PR TITLE
Add postponed_sieve_eratosthenes

### DIFF
--- a/nprime/pyprime.py
+++ b/nprime/pyprime.py
@@ -174,7 +174,7 @@ def postponed_sieve_eratosthenes(start=0):
         >>> # Generate larger primes in the billions
         >>> generator = postponed_sieve_eratosthenes(start=500_000_000)
         >>> list(islice(generator, 0, 5))
-        [500000101, 500000117, 500000183, 500000201, 500000227]
+        [500000003, 500000009, 500000041, 500000057, 500000069]
 
     Example:
         >>> # xdoctest: +SKIP("can stress older hardware")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.pytest.ini_options]
+addopts = "--xdoctest --xdoctest-style=google --ignore-glob=setup.py --ignore-glob=docs --ignore-glob=demo"
+norecursedirs = ".git build __pycache__ demo docs"
+filterwarnings = [
+    "default",
+]

--- a/tests/test_postponed_eratosthenes.py
+++ b/tests/test_postponed_eratosthenes.py
@@ -1,0 +1,19 @@
+import unittest
+
+from nprime.pyprime import postponed_sieve_eratosthenes
+from tests.prime_testcase import FIRST_PRIMES
+from itertools import islice
+
+
+class TestPostponedSieve(unittest.TestCase):
+    """ Tests for postponed sieve of eratosthenes """
+
+    def test_first_few_primes(self):
+        """ Making sure that all keys from the trial_division are prime  """
+        generator = postponed_sieve_eratosthenes()
+        first_primes = list(islice(generator, 0, len(FIRST_PRIMES)))
+        self.assertEqual(FIRST_PRIMES, first_primes)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Implements #27 

I went a bit further and implemented the extension so the generation more efficiently start at a larger prime.

I only added one unit test as this didn't follow the same pattern as the other functions (it just generates prime integers instead of returning mappings), but the main cases are covered between that and the doctests.

Speaking of the doctests, running `pytest` in the repo root wasn't running them by default. I added a simple pyproject.toml so those are enabled. 